### PR TITLE
Rcb 515 portability

### DIFF
--- a/rosette_api/CAPI.cs
+++ b/rosette_api/CAPI.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace rosette_api {
     /// <summary>
@@ -70,7 +70,7 @@ namespace rosette_api {
         /// <param name="client">(HttpClient, optional): Forces the API to use a custom HttpClient.</param>
         public CAPI(string user_key, string uristring = "https://api.rosette.com/rest/v1/", int maxRetry = 5, HttpClient client = null) {
             UserKey = user_key;
-            URIstring = (uristring == null) ? "https://api.rosette.com/rest/v1/" : uristring;
+            URIstring = uristring ?? "https://api.rosette.com/rest/v1/";
             MaxRetry = (maxRetry == 0) ? 1 : maxRetry;
             MillisecondsBetweenRetries = 5000;
             Debug = false;
@@ -217,7 +217,7 @@ namespace rosette_api {
             _customHeaders.Clear();
         }
 
-        private Dictionary<object, object> appendOptions(Dictionary<object, object> dict) {
+        private Dictionary<object, object> AppendOptions(Dictionary<object, object> dict) {
             if (_options.Count > 0) {
                 dict["options"] = _options;
             }
@@ -255,7 +255,7 @@ namespace rosette_api {
         public CategoriesResponse Categories(Dictionary<object, object> dict)
         {
             _uri = "categories";
-            return getResponse<CategoriesResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<CategoriesResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Categories
@@ -301,7 +301,7 @@ namespace rosette_api {
         public EntitiesResponse Entity(Dictionary<object, object> dict)
         {
             _uri = "entities";
-            return getResponse<EntitiesResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<EntitiesResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Entity
@@ -326,7 +326,7 @@ namespace rosette_api {
         public InfoResponse Info()
         {
             _uri = "info";
-            return getResponse<InfoResponse>(SetupClient());
+            return GetResponse<InfoResponse>(SetupClient());
         }
 
         /// <summary>Language
@@ -360,7 +360,7 @@ namespace rosette_api {
         public LanguageIdentificationResponse Language(Dictionary<object, object> dict)
         {
             _uri = "language";
-            return getResponse<LanguageIdentificationResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<LanguageIdentificationResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Language
@@ -412,7 +412,7 @@ namespace rosette_api {
         public MorphologyResponse Morphology(Dictionary<object, object> dict, MorphologyFeature feature = MorphologyFeature.complete)
         {
             _uri = "morphology/" + feature.MorphologyEndpoint();
-            return getResponse<MorphologyResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<MorphologyResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Morphology
@@ -449,7 +449,7 @@ namespace rosette_api {
                 { "name2", n2}
             };
 
-            return getResponse<NameSimilarityResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<NameSimilarityResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>MatchedName
@@ -477,7 +477,7 @@ namespace rosette_api {
         /// </returns>
         public NameSimilarityResponse NameSimilarity(Dictionary<object, object> dict) {
             _uri = "name-similarity";
-            return getResponse<NameSimilarityResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<NameSimilarityResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>NameDeduplication
@@ -498,7 +498,7 @@ namespace rosette_api {
                 { "threshold", threshold}
             };
 
-            return getResponse<NameDeduplicationResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<NameDeduplicationResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>NameDeduplication
@@ -511,7 +511,7 @@ namespace rosette_api {
         /// </returns>
         public NameDeduplicationResponse NameDeduplication(Dictionary<object, object> dict) {
             _uri = "name-deduplication";
-            return getResponse<NameDeduplicationResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<NameDeduplicationResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Transliteration
@@ -533,7 +533,7 @@ namespace rosette_api {
                 { "language", language }
             }.Where(f => f.Value != null).ToDictionary(x => x.Key, x => x.Value);
 
-            return getResponse<TransliterationResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<TransliterationResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Transliteration
@@ -546,7 +546,7 @@ namespace rosette_api {
         /// </returns>
         public TransliterationResponse Transliteration(Dictionary<object, object> dict) {
             _uri = "transliteration";
-            return getResponse<TransliterationResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<TransliterationResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Ping
@@ -565,7 +565,7 @@ namespace rosette_api {
 
         public PingResponse Ping() {
             _uri = "ping";
-            return getResponse<PingResponse>(SetupClient());
+            return GetResponse<PingResponse>(SetupClient());
         }
 
         /// <summary>TextEmbeddings
@@ -609,7 +609,7 @@ namespace rosette_api {
         public TextEmbeddingResponse TextEmbedding(Dictionary<object, object> dict)
         {
             _uri = "text-embedding";
-            return getResponse<TextEmbeddingResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<TextEmbeddingResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>TextEmbeddings
@@ -665,7 +665,7 @@ namespace rosette_api {
         public SyntaxDependenciesResponse SyntaxDependencies(Dictionary<object, object> dict)
         {
             _uri = "syntax/dependencies";
-            return getResponse<SyntaxDependenciesResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<SyntaxDependenciesResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>SyntaxDependencies
@@ -731,7 +731,7 @@ namespace rosette_api {
         public RelationshipsResponse Relationships(Dictionary<object, object> dict)
         {
             _uri = "relationships";
-            return getResponse<RelationshipsResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<RelationshipsResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Relationships
@@ -787,7 +787,7 @@ namespace rosette_api {
         public SentenceTaggingResponse Sentences(Dictionary<object, object> dict)
         {
             _uri = "sentences";
-            return getResponse<SentenceTaggingResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<SentenceTaggingResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Sentences
@@ -835,7 +835,7 @@ namespace rosette_api {
         public SentimentResponse Sentiment(Dictionary<object, object> dict)
         {
             _uri = "sentiment";
-            return getResponse<SentimentResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<SentimentResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Sentiment
@@ -882,7 +882,7 @@ namespace rosette_api {
         /// </returns>
         public TokenizationResponse Tokens(Dictionary<object, object> dict) {
             _uri = "tokens";
-            return getResponse<TokenizationResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<TokenizationResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>Tokens
@@ -930,7 +930,7 @@ namespace rosette_api {
                 { "genre", genre}
             }.Where(f => f.Value != null).ToDictionary(x => x.Key, x => x.Value);
 
-            return getResponse<TranslateNamesResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<TranslateNamesResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>NameTranslation
@@ -942,7 +942,7 @@ namespace rosette_api {
         /// <returns>TranslateNamesResponse containing the results of the request. </returns>
         public TranslateNamesResponse NameTranslation(Dictionary<object, object> dict) {
             _uri = "name-translation";
-            return getResponse<TranslateNamesResponse>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<TranslateNamesResponse>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>getResponse
@@ -954,7 +954,7 @@ namespace rosette_api {
         /// <param name="jsonRequest">(string, optional): Content to use as the request to the server with POST. If none given, assume an Info endpoint and use GET</param>
         /// <param name="multiPart">(MultipartFormDataContent, optional): Used for file uploads</param>
         /// <returns>RosetteResponse derivative</returns>
-        private T getResponse<T>(HttpClient client, string jsonRequest = null, MultipartFormDataContent multiPart = null) where T : RosetteResponse {
+        private T GetResponse<T>(HttpClient client, string jsonRequest = null, MultipartFormDataContent multiPart = null) where T : RosetteResponse {
             HttpResponseMessage responseMsg = null;
             if (client != null) {
                 string wholeURI = _uri;
@@ -992,7 +992,7 @@ namespace rosette_api {
             }
             else
             {
-                throw new RosetteException(string.Format("{0}: {1}", responseMsg.ReasonPhrase, RosetteResponse.contentToString(responseMsg.Content)), (int)responseMsg.StatusCode);
+                throw new RosetteException(string.Format("{0}: {1}", responseMsg.ReasonPhrase, RosetteResponse.ContentToString(responseMsg.Content)), (int)responseMsg.StatusCode);
             }
         }
 
@@ -1022,7 +1022,7 @@ namespace rosette_api {
         /// <param name="file">RosetteFile: File being uploaded to use as a request to the Rosette server.</param>
         /// <returns>RosetteResponse derivative containing the results of the response from the server from the getResponse call.</returns>
         private T Process<T>(RosetteFile file) where T : RosetteResponse {
-            return getResponse<T>(SetupClient(), null, file.AsMultipart());
+            return GetResponse<T>(SetupClient(), null, file.AsMultipart());
         }
 
         /// <summary>Process
@@ -1055,7 +1055,7 @@ namespace rosette_api {
                 { "genre", genre}
             }.Where(f => f.Value != null).ToDictionary(x => x.Key, x => x.Value);
 
-            return getResponse<T>(SetupClient(), new JavaScriptSerializer().Serialize(appendOptions(dict)));
+            return GetResponse<T>(SetupClient(), JsonConvert.SerializeObject(AppendOptions(dict)));
         }
 
         /// <summary>SetupClient
@@ -1077,8 +1077,9 @@ namespace rosette_api {
                         new HttpClientHandler {
                             AutomaticDecompression = DecompressionMethods.GZip
                                                      | DecompressionMethods.Deflate
-                        });
-                client.BaseAddress = new Uri(URIstring);
+                        }) {
+                        BaseAddress = new Uri(URIstring)
+                    };
                 if (Timeout != 0) {
                     client.Timeout = TimeSpan.FromMilliseconds(Timeout);
                 }

--- a/rosette_api/MorphologyResponse.cs
+++ b/rosette_api/MorphologyResponse.cs
@@ -36,15 +36,15 @@ namespace rosette_api
         public MorphologyResponse(HttpResponseMessage apiResponse) : base(apiResponse)
         {
             JArray tokensArr = this.ContentDictionary.ContainsKey(tokenKey) ? this.ContentDictionary[tokenKey] as JArray : null;
-            List<string> tokens = tokensArr != null ? new List<string>(tokensArr.Select<JToken, string>((jToken) => jToken != null ? jToken.ToString() : null)) : null;
+            List<string> tokens = tokensArr != null ? new List<string>(tokensArr.Select((jToken) => jToken?.ToString())) : null;
             JArray lemmasArr = this.ContentDictionary.ContainsKey(lemmasKey) ? this.ContentDictionary[lemmasKey] as JArray : null;
-            List<string> lemmas = lemmasArr != null ? new List<string>(lemmasArr.Select<JToken, string>((jToken) => jToken != null ? jToken.ToString() : null)) : null;
+            List<string> lemmas = lemmasArr != null ? new List<string>(lemmasArr.Select<JToken, string>((jToken) => jToken?.ToString())) : null;
             JArray posTagsArr = this.ContentDictionary.ContainsKey(posTagsKey) ? this.ContentDictionary[posTagsKey] as JArray : null;
-            List<string> posTags = posTagsArr != null ? new List<string>(posTagsArr.Select<JToken, string>((jToken) => jToken != null ? jToken.ToString() : null)) : null;
+            List<string> posTags = posTagsArr != null ? new List<string>(posTagsArr.Select<JToken, string>((jToken) => jToken?.ToString())) : null;
             JArray compoundComponentsArr = this.ContentDictionary.ContainsKey(compoundComponentsKey) ? this.ContentDictionary[compoundComponentsKey] as JArray : null;
-            List<List<string>> compoundComponents = compoundComponentsArr != null ? new List<List<string>>(compoundComponentsArr.Select<JToken, List<string>>((jToken) => jToken != null ? jToken.ToObject<List<string>>() : null)) : null;
+            List<List<string>> compoundComponents = compoundComponentsArr != null ? new List<List<string>>(compoundComponentsArr.Select<JToken, List<string>>((jToken) => jToken?.ToObject<List<string>>())) : null;
             JArray hanReadingsArr = this.ContentDictionary.ContainsKey(hanReadingsKey) ? this.ContentDictionary[hanReadingsKey] as JArray : null;
-            List<List<string>> hanReadings = hanReadingsArr != null ? new List<List<string>>(hanReadingsArr.Select<JToken, List<string>>((jToken) => jToken != null ? jToken.ToObject<List<string>>() : null)) : null;
+            List<List<string>> hanReadings = hanReadingsArr != null ? new List<List<string>>(hanReadingsArr.Select<JToken, List<string>>((jToken) => jToken?.ToObject<List<string>>())) : null;
             this.Items = this.MakeMorphologyItems(tokens, lemmas, posTags, compoundComponents, hanReadings);
         }
 

--- a/rosette_api/NameDeduplicationResponse.cs
+++ b/rosette_api/NameDeduplicationResponse.cs
@@ -26,7 +26,7 @@ namespace rosette_api {
             if (this.ContentDictionary.ContainsKey(nameDeduplicationKey)) {
                 this.Results = this.ContentDictionary[nameDeduplicationKey] as List<string>;
                 JArray resultsArr = this.ContentDictionary.ContainsKey(nameDeduplicationKey) ? this.ContentDictionary[nameDeduplicationKey] as JArray : null;
-                this.Results = resultsArr != null ? new List<string>(resultsArr.Select<JToken, string>((jToken) => jToken != null ? jToken.ToString() : null)) : null;
+                this.Results = resultsArr != null ? new List<string>(resultsArr.Select<JToken, string>((jToken) => jToken?.ToString())) : null;
 
             }
         }
@@ -41,7 +41,7 @@ namespace rosette_api {
             if (this.ContentDictionary.ContainsKey(nameDeduplicationKey)) {
                 this.Results = this.ContentDictionary[nameDeduplicationKey] as List<string>;
                 JArray resultsArr = this.ContentDictionary.ContainsKey(nameDeduplicationKey) ? this.ContentDictionary[nameDeduplicationKey] as JArray : null;
-                this.Results = resultsArr != null ? new List<string>(resultsArr.Select<JToken, string>((jToken) => jToken != null ? jToken.ToString() : null)) : null;
+                this.Results = resultsArr != null ? new List<string>(resultsArr.Select<JToken, string>((jToken) => jToken?.ToString())) : null;
 
             }
         }

--- a/rosette_api/Properties/AssemblyInfo.cs
+++ b/rosette_api/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.7.2.0")]
-[assembly: AssemblyVersion("1.7.2.0")]
-[assembly: AssemblyFileVersion("1.7.2.0")]
+[assembly: AssemblyVersion("1.7.3.0")]
+[assembly: AssemblyFileVersion("1.7.3.0")]

--- a/rosette_api/RelationshipsResponse.cs
+++ b/rosette_api/RelationshipsResponse.cs
@@ -311,9 +311,10 @@ namespace rosette_api
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            JsonSerializer relationshipSerializer = new JsonSerializer();
-            relationshipSerializer.NullValueHandling = NullValueHandling.Ignore;
-            relationshipSerializer.ContractResolver = new RelationshipContractResolver(value as RosetteRelationship);
+            JsonSerializer relationshipSerializer = new JsonSerializer() {
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new RelationshipContractResolver(value as RosetteRelationship)
+            };
             JsonObjectContract contract = (JsonObjectContract)relationshipSerializer.ContractResolver.ResolveContract(value.GetType());
 
             writer.WriteStartObject();
@@ -373,12 +374,13 @@ namespace rosette_api
 
         private JsonProperty CreateNewCustomProperty(int order, string name, Type valueType, object value)
         {
-            JsonProperty argProp = new JsonProperty();
-            argProp.Order = order;
-            argProp.PropertyName = name;
-            argProp.PropertyType = valueType;
-            argProp.HasMemberAttribute = true;
-            argProp.ValueProvider = new StaticValueProvider(value);
+            JsonProperty argProp = new JsonProperty() {
+                Order = order,
+                PropertyName = name,
+                PropertyType = valueType,
+                HasMemberAttribute = true,
+                ValueProvider = new StaticValueProvider(value)
+            };
             argProp.Ignored = argProp.ValueProvider.GetValue("Not needed") == null;
             return argProp;
         }
@@ -502,9 +504,10 @@ namespace rosette_api
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            JsonSerializer argumentSerializer = new JsonSerializer();
-            argumentSerializer.NullValueHandling = NullValueHandling.Ignore;
-            argumentSerializer.ContractResolver = new ArgumentContractResolver(value as Argument);
+            JsonSerializer argumentSerializer = new JsonSerializer() {
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new ArgumentContractResolver(value as Argument)
+            };
             JsonObjectContract contract = (JsonObjectContract)argumentSerializer.ContractResolver.ResolveContract(value.GetType());
 
             writer.WriteStartObject();

--- a/rosette_api/RosetteException.cs
+++ b/rosette_api/RosetteException.cs
@@ -70,5 +70,6 @@ namespace rosette_api {
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) {
             base.GetObjectData(info, context);
         }
+
     }
 }

--- a/rosette_api/RosetteResponse.cs
+++ b/rosette_api/RosetteResponse.cs
@@ -21,7 +21,6 @@ namespace rosette_api {
         /// <summary>
         /// IDictionary of response content
         /// </summary>
-        [Obsolete("The structure of this property is subject to change.  Please use the data structures provided in the Response classes that inherit from the RosetteResponse class instead.")]
         public IDictionary<string, object> Content { get; private set; }
         /// <summary>
         /// IDictionary of response content
@@ -143,6 +142,22 @@ namespace rosette_api {
             serializer.Serialize(writer, this.Content);
 # pragma warning restore 618
             return builder.ToString();
+        }
+
+        /// <summary>
+        /// Provides a method for recursively printing the Content dictionary to the console.
+        /// </summary>
+        public void PrintContent(IDictionary<string, object> content = null) {
+            if (content == null) {
+                content = Content;
+            }
+
+            foreach (var pair in content) {
+                if (content[pair.Key].GetType().GetInterfaces().Any(x => x.Name == "IDictionary")) {
+                    PrintContent((IDictionary<string, object>)(content[pair.Key]));
+                }
+                Console.WriteLine("{0}: {1}", pair.Key, pair.Value.ToString());
+            }
         }
 
         /// <summary>

--- a/rosette_api/RosetteResponse.cs
+++ b/rosette_api/RosetteResponse.cs
@@ -64,7 +64,7 @@ namespace rosette_api {
 #pragma warning disable 618
             this.Content = ContentDictionary;
 #pragma warning restore 618
-            this.Headers = headers != null ? headers : new Dictionary<string, string>();
+            this.Headers = headers ?? new Dictionary<string, string>();
             this.ResponseHeaders = new ResponseHeaders(this.Headers);
             if (contentAsJson != null)
             {
@@ -98,26 +98,20 @@ namespace rosette_api {
                 this.ResponseHeaders = new ResponseHeaders(this.Headers);
                 byte[] byteArray = responseMsg.Content.ReadAsByteArrayAsync().Result;
                 if(byteArray[0] == '\x1f' && byteArray[1] == '\x8b' && byteArray[2] == '\x08') {
-                    byteArray = decompress(byteArray);
+                    byteArray = Decompress(byteArray);
                 }
-                MemoryStream stream = new MemoryStream(byteArray);
-                try {
-                    using (StreamReader reader = new StreamReader(stream, Encoding.UTF8)) {
-                        ContentAsJson = reader.ReadToEnd();
-                    }
+                using (MemoryStream stream = new MemoryStream(byteArray))
+                using (StreamReader reader = new StreamReader(stream, Encoding.UTF8)) {
+                    ContentAsJson = reader.ReadToEnd();
                 }
-                finally {
-                    if (stream != null) {
-                        stream.Dispose();
-                    }
-                }
+
                 this.ContentDictionary = Serializer.Deserialize<Dictionary<string, object>>(new JsonTextReader(new StringReader(this.ContentAsJson)));
 # pragma warning disable 618
                 this.Content = ContentDictionary;
 # pragma warning restore 618
             }
             else {
-                throw new RosetteException(string.Format("{0}: {1}", responseMsg.ReasonPhrase, contentToString(responseMsg.Content)), (int)responseMsg.StatusCode);
+                throw new RosetteException(string.Format("{0}: {1}", responseMsg.ReasonPhrase, ContentToString(responseMsg.Content)), (int)responseMsg.StatusCode);
             }
         }
 
@@ -156,7 +150,7 @@ namespace rosette_api {
         /// </summary>
         /// <param name="httpContent"></param>
         /// <returns></returns>
-        internal static string contentToString(HttpContent httpContent) {
+        internal static string ContentToString(HttpContent httpContent) {
             if (httpContent != null) {
                 var readAsStringAsync = httpContent.ReadAsStringAsync();
                 return readAsStringAsync.Result;
@@ -182,7 +176,7 @@ namespace rosette_api {
         /// </summary>
         /// <param name="gzip">(byte[]): Data in byte form to decompress</param>
         /// <returns>(byte[]) Decompressed data</returns>
-        private byte[]decompress(byte[] gzip) {
+        private byte[]Decompress(byte[] gzip) {
             // Create a GZIP stream with decompression mode.
             // ... Then create a buffer and write into while reading from the GZIP stream.
             using (GZipStream stream = new GZipStream(new MemoryStream(gzip), CompressionMode.Decompress)) {

--- a/rosette_api/rosette_api.csproj
+++ b/rosette_api/rosette_api.csproj
@@ -45,11 +45,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/rosette_api/rosette_api.nuspec
+++ b/rosette_api/rosette_api.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>rosette_api</id>
-    <version>1.7.0</version>                                            
+    <version>1.7.0</version>
     <authors>basistech</authors>
     <owners>basistech</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
@@ -16,7 +16,6 @@
     </dependencies>
 	<frameworkAssemblies>
 		<frameworkAssembly assemblyName="System.Net.Http" targetFramework="net45" />
-		<frameworkAssembly assemblyName="System.Web.Extensions" targetFramework="net45" />
 	</frameworkAssemblies>
   </metadata>
   <files>

--- a/rosette_apiExamples/entities.cs
+++ b/rosette_apiExamples/entities.cs
@@ -38,6 +38,13 @@ namespace rosette_apiExamples
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
                 }
                 Console.WriteLine(response.ToString());
+
+                // Entities with full ADM
+                EntitiesCAPI.SetUrlParameter("output", "rosette");
+                response = EntitiesCAPI.Entity(entities_text_data, null, null, null, "social-media");
+                // response.Content contains the IDictionary results of the full ADM.
+                // PrintContent() is a provided method to print the Dictionary to the console
+                response.PrintContent();
             }
             catch (Exception e)
             {

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -1,15 +1,14 @@
-﻿using LinqToExcel;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using rosette_api;
 using RichardSzalay.MockHttp;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Web.Script.Serialization;
 using Newtonsoft.Json;
 
@@ -358,6 +357,42 @@ namespace rosette_apiUnitTests {
                 Assert.AreEqual(ex.Message, "Custom header name must begin with \"X-RosetteAPI-\"");
                 return;
             }
+        }
+
+
+        //------------------------- Simple URL Parameter Tests ----------------------------------------
+
+
+        [Test]
+        public void CustomUrlParametersTest() {
+            NameValueCollection expected = new NameValueCollection();
+            expected.Add("output", "rosette");
+
+            _rosetteApi.SetUrlParameter("output", "rosette");
+
+            Assert.AreEqual(expected["output"], _rosetteApi.GetUrlParameters()["output"]);
+        }
+
+        [Test]
+        public void ClearUrlParametersTest() {
+            NameValueCollection expected = new NameValueCollection();
+            expected.Add("output", "rosette");
+
+            _rosetteApi.SetUrlParameter("output", "rosette");
+
+            _rosetteApi.ClearUrlParameters();
+
+            Assert.IsEmpty(_rosetteApi.GetUrlParameters());
+        }
+
+        [Test]
+        public void RemoveURLParametersTest() {
+            NameValueCollection expected = new NameValueCollection();
+            expected.Add("output", "rosette");
+
+            _rosetteApi.RemoveUrlParameter("output");
+
+            Assert.IsEmpty(_rosetteApi.GetUrlParameters());
         }
 
 

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json;
 namespace rosette_apiUnitTests {
 
     [TestFixture]
-    public class rosetteResponseTests {
+    public class RosetteResponseTests {
         private string _testHeaderKey;
         private string _testHeaderValue;
         private string _testJson;
@@ -87,7 +87,7 @@ namespace rosette_apiUnitTests {
     }
 
     [TestFixture]
-    public class rosetteExtensionsTests {
+    public class RosetteExtensionsTests {
         [Test]
         public void MorphologyEndpointTest() {
             string expected = "han-readings";
@@ -96,7 +96,7 @@ namespace rosette_apiUnitTests {
     }
 
     [TestFixture]
-    public class rosette_errorTests : IDisposable {
+    public class Rosette_errorTests : IDisposable {
         bool disposed = false;
 
         public void Dispose() {
@@ -157,7 +157,7 @@ namespace rosette_apiUnitTests {
     }
 
     [TestFixture]
-    public class rosette_classTests {
+    public class Rosette_classTests {
         [Test]
         public void NameClassTest() {
             Name name = new Name("text", "language", "script", "entityType");
@@ -208,7 +208,7 @@ namespace rosette_apiUnitTests {
     }
 
     [TestFixture]
-    public class rosette_apiUnitTests : IDisposable {
+    public class Rosette_apiUnitTests : IDisposable {
         bool disposed = false;
 
         public void Dispose() {
@@ -383,11 +383,12 @@ namespace rosette_apiUnitTests {
             string buildNumber = null;
             string buildTime = null;
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": 72, \"connection\": \"Close\" }";
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("name", name);
-            content.Add("version", version);
-            content.Add("buildNumber", buildNumber);
-            content.Add("buildTime", buildTime);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "name", name },
+                { "version", version },
+                { "buildNumber", buildNumber },
+                { "buildTime", buildTime }
+            };
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, new JavaScriptSerializer().Serialize(content));
             _mockHttp.When(_testUrl + "info").Respond(mockedMessage);
@@ -398,8 +399,9 @@ namespace rosette_apiUnitTests {
 
         private HttpResponseMessage MakeMockedMessage(Dictionary<string, string> responseHeaders, HttpStatusCode statusCode, String content)
         {
-            HttpResponseMessage mockedMessage = new HttpResponseMessage(statusCode);
-            mockedMessage.Content = new StringContent(content);
+            HttpResponseMessage mockedMessage = new HttpResponseMessage(statusCode) {
+                Content = new StringContent(content)
+            };
             foreach (KeyValuePair<string, string> header in responseHeaders)
             {
                 try
@@ -434,9 +436,10 @@ namespace rosette_apiUnitTests {
             string message = "Rosette API at your service.";
             long time = 1470930452887;
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("message", message);
-            content.Add("time", time);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "message", message },
+                { "time", time }
+            };
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, new JavaScriptSerializer().Serialize(content));
             _mockHttp.When(_testUrl + "ping").Respond(mockedMessage);
@@ -515,8 +518,9 @@ namespace rosette_apiUnitTests {
             RosetteCategory cat0 = new RosetteCategory("ARTS_AND_ENTERTAINMENT", (decimal)0.23572849069656435);
             categories.Add(cat0);
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("categories", categories);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "categories", categories }
+            };
             Dictionary<string, string> responseHeaders = serializer.Deserialize<Dictionary<string, string>>(new JsonTextReader(new StringReader(headersAsString)));
             String mockedContent = "{\"categories\": [ { \"label\": \"" + cat0.Label + "\", \"confidence\": " + cat0.Confidence + "} ] }";
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -560,8 +564,9 @@ namespace rosette_apiUnitTests {
             List<RosetteEntity> entities = new List<RosetteEntity>() { e0, e1 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("entities", entities);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "entities", entities }
+            };
             EntitiesResponse expected = new EntitiesResponse(entities, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -607,8 +612,9 @@ namespace rosette_apiUnitTests {
         [Test]
         public void EntityIDTestPassOnCreate()
         {
-            EntityID pass = new EntityID("Q1");
-            pass.ID = "Q1";
+            EntityID pass = new EntityID("Q1") {
+                ID = "Q1"
+            };
             Assert.AreEqual("https://en.wikipedia.org/wiki/Universe", pass.GetWikipedaURL());
         }
 
@@ -645,8 +651,9 @@ namespace rosette_apiUnitTests {
             List<LanguageDetection> languageDetections = new List<LanguageDetection>() { lang0, lang1, lang2, lang3, lang4, lang5, lang6, lang7, lang8 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("languageDetections", languageDetections);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "languageDetections", languageDetections }
+            };
             LanguageIdentificationResponse expected = new LanguageIdentificationResponse(languageDetections, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -703,12 +710,13 @@ namespace rosette_apiUnitTests {
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1, m2, m3, m4, m5 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)));
-            content.Add("posTags", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.PosTag)));
-            content.Add("lemmas", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Lemma)));
-            content.Add("compoundComponents", new List<List<string>>(morphology.Select<MorphologyItem, List<string>>((item) => item.CompoundComponents)));
-            content.Add("hanReadings", new List<List<string>>(morphology.Select<MorphologyItem, List<string>>((item) => item.HanReadings)));
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) },
+                { "posTags", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.PosTag)) },
+                { "lemmas", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Lemma)) },
+                { "compoundComponents", new List<List<string>>(morphology.Select<MorphologyItem, List<string>>((item) => item.CompoundComponents)) },
+                { "hanReadings", new List<List<string>>(morphology.Select<MorphologyItem, List<string>>((item) => item.HanReadings)) }
+            };
             MorphologyResponse expected = new MorphologyResponse(morphology, responseHeaders, content, null);
             String mockedContent = expected.ContentAsJson;
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -730,8 +738,10 @@ namespace rosette_apiUnitTests {
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1, m2, m3, m4, m5 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)));;
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) }
+            };
+            ;
             content.Add("lemmas", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Lemma)));
             MorphologyResponse expected = new MorphologyResponse(morphology, responseHeaders, content, null);
             String mockedContent = expected.ContentAsJson;
@@ -751,8 +761,10 @@ namespace rosette_apiUnitTests {
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token))); ;
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) }
+            };
+            ;
             content.Add("compoundComponents", new List<List<string>>(morphology.Select<MorphologyItem, List<string>>((item) => item.CompoundComponents)));
             MorphologyResponse expected = new MorphologyResponse(morphology, responseHeaders, content, null);
             String mockedContent = expected.ContentAsJson;
@@ -775,8 +787,10 @@ namespace rosette_apiUnitTests {
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1, m2 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token))); ;
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) }
+            };
+            ;
             content.Add("hanReadings", new List<List<string>>(morphology.Select<MorphologyItem, List<string>>((item) => item.HanReadings)));
             MorphologyResponse expected = new MorphologyResponse(morphology, responseHeaders, content, null);
             String mockedContent = expected.ContentAsJson;
@@ -828,8 +842,9 @@ namespace rosette_apiUnitTests {
             double score = (double)0.9486632809417912;
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("score", score);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "score", score }
+            };
             NameSimilarityResponse expected = new NameSimilarityResponse(score, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -950,8 +965,9 @@ namespace rosette_apiUnitTests {
             List<RosetteRelationship> relationships = new List<RosetteRelationship>() {
                 new RosetteRelationship(predicate, new Dictionary<int, string>() {{1, arg1}}, new Dictionary<int, string>() {{1, arg1ID}}, null, locatives, null, confidence, modalities)
             };
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("relationships", relationships);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "relationships", relationships }
+            };
             RelationshipsResponse expected = new RelationshipsResponse(relationships, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -975,8 +991,9 @@ namespace rosette_apiUnitTests {
             List<RosetteRelationship> relationships = new List<RosetteRelationship>() {
                 new RosetteRelationship(predicate, new Dictionary<int, string>() {{1, arg1}}, new Dictionary<int, string>(), null, locatives, null, confidence, modalities)
             };
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("relationships", relationships);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "relationships", relationships }
+            };
             RelationshipsResponse expected = new RelationshipsResponse(relationships, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -1043,8 +1060,9 @@ namespace rosette_apiUnitTests {
             List<double> vector = new List<double>() {0.02164695, 0.0032850206, 0.0038508752, -0.009704393, -0.0016203842};
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("embedding", vector);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "embedding", vector }
+            };
             TextEmbeddingResponse expected = new TextEmbeddingResponse(vector, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -1102,8 +1120,9 @@ namespace rosette_apiUnitTests {
             List<string> sentences = new List<string>() { s0, s1, s2 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("sentences", sentences);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "sentences", sentences }
+            };
             SentenceTaggingResponse expected = new SentenceTaggingResponse(sentences, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -1157,9 +1176,10 @@ namespace rosette_apiUnitTests {
             List<RosetteSentimentEntity> entities = new List<RosetteSentimentEntity>() { e0, e1 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("document", docSentiment);
-            content.Add("entities", entities);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "document", docSentiment },
+                { "entities", entities }
+            };
             SentimentResponse expected = new SentimentResponse(docSentiment, entities, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -1256,9 +1276,10 @@ namespace rosette_apiUnitTests {
             List<string> tokens = new List<string>() { "Sony", "Pictures", "is", "planning", "."};
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("sentences", sentences);
-            content.Add("tokens", tokens);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "sentences", sentences },
+                { "tokens", tokens }
+            };
             SyntaxDependenciesResponse expected = new SyntaxDependenciesResponse(sentences, tokens, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -1319,8 +1340,9 @@ namespace rosette_apiUnitTests {
             };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("tokens", tokens);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "tokens", tokens }
+            };
             TokenizationResponse expected = new TokenizationResponse(tokens, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
@@ -1375,12 +1397,13 @@ namespace rosette_apiUnitTests {
             double confidence = (double)0.06856099342585828;
             string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object>();
-            content.Add("translation", translation);
-            content.Add("targetLanguage", targetLanguage);
-            content.Add("targetScript", targetScript);
-            content.Add("targetScheme", targetScheme);
-            content.Add("confidence", confidence);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "translation", translation },
+                { "targetLanguage", targetLanguage },
+                { "targetScript", targetScript },
+                { "targetScheme", targetScheme },
+                { "confidence", confidence }
+            };
             TranslateNamesResponse expected = new TranslateNamesResponse(translation, targetLanguage: targetLanguage, targetScript:targetScript, targetScheme:targetScheme, confidence: confidence, responseHeaders:responseHeaders, content: content);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);


### PR DESCRIPTION
- Added Url Parameter methods
- Added unit tests for Url Parameter methods
- Added ToQueryString() to create Uri query string
- Added logic to add query string if parameters are provided
- Updated entities example to demonstrate Url Parameters (as an addition)
- Code cleanup
- Portability changes, portability analyzer shows 100% compatibility with .NET core