### PR TITLE
DEVOPS-225:  Add permId and dbPediaTypes for 19.08 release.

### DIFF
--- a/rosette_api/EntitiesResponse.cs
+++ b/rosette_api/EntitiesResponse.cs
@@ -31,6 +31,7 @@ namespace rosette_api
         private const String countKey = "count";
         private const String confidenceKey = "confidence";
         private const String dbpediaTypeKey = "dbpediaType";
+        private const String dbpediaTypesKey = "dbpediaTypes";
         private const String mentionOffsetsKey = "mentionOffsets";
         private const String linkingConfidenceKey = "linkingConfidence";
         private const String salienceKey = "salience";
@@ -54,12 +55,13 @@ namespace rosette_api
                 Nullable<int> count = result.Properties().Where((p) => String.Equals(p.Name, countKey)).Any() ? result[countKey].ToObject<int?>() : null;
                 Nullable<double> confidence = result.Properties().Where((p) => String.Equals(p.Name, confidenceKey)).Any() ? result[confidenceKey].ToObject<double?>() : null;
                 String dbpediaType = result.Properties().Where((p) => String.Equals(p.Name, dbpediaTypeKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[dbpediaTypeKey].ToString() : null;
-                JArray mentionOffsetsArr = result.Properties().Where((p) => String.Equals(p.Name, dbpediaTypeKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[mentionOffsetsKey] as JArray : null;
+                List<String> dbpediaTypes = result.Properties().Where((p) => String.Equals(p.Name, dbpediaTypesKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[dbpediaTypesKey].ToObject<List<String>>() : null;
+                JArray mentionOffsetsArr = result.Properties().Where((p) => String.Equals(p.Name, mentionOffsetsKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[mentionOffsetsKey] as JArray : null;
                 List<MentionOffset> mentionOffsets = mentionOffsetsArr != null ? mentionOffsetsArr.ToObject<List<MentionOffset>>() : null;
                 Nullable<double> linkingConfidence = result.Properties().Where((p) => String.Equals(p.Name, linkingConfidenceKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[linkingConfidenceKey].ToObject<double?>() : null;
                 Nullable<double> salience = result.Properties().Where((p) => String.Equals(p.Name, salienceKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[salienceKey].ToObject<double?>() : null;
                 String permId = result.Properties().Where((p) => String.Equals(p.Name, permIdKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[permIdKey].ToString() : null;
-                entities.Add(new RosetteEntity(mention, normalized, entityID, type, count, confidence, dbpediaType, mentionOffsets, linkingConfidence, salience, permId));
+                entities.Add(new RosetteEntity(mention, normalized, entityID, type, count, confidence, dbpediaType, dbpediaTypes, mentionOffsets, linkingConfidence, salience, permId));
             }
             this.Entities = entities;
         }

--- a/rosette_api/EntitiesResponse.cs
+++ b/rosette_api/EntitiesResponse.cs
@@ -34,6 +34,7 @@ namespace rosette_api
         private const String mentionOffsetsKey = "mentionOffsets";
         private const String linkingConfidenceKey = "linkingConfidence";
         private const String salienceKey = "salience";
+        private const String permIdKey = "permId";
 
         /// <summary>
         /// Creates an EntitiesResponse from the API's raw output
@@ -57,7 +58,8 @@ namespace rosette_api
                 List<MentionOffset> mentionOffsets = mentionOffsetsArr != null ? mentionOffsetsArr.ToObject<List<MentionOffset>>() : null;
                 Nullable<double> linkingConfidence = result.Properties().Where((p) => String.Equals(p.Name, linkingConfidenceKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[linkingConfidenceKey].ToObject<double?>() : null;
                 Nullable<double> salience = result.Properties().Where((p) => String.Equals(p.Name, salienceKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[salienceKey].ToObject<double?>() : null;
-                entities.Add(new RosetteEntity(mention, normalized, entityID, type, count, confidence, dbpediaType, mentionOffsets, linkingConfidence, salience));
+                String permId = result.Properties().Where((p) => String.Equals(p.Name, permIdKey, StringComparison.OrdinalIgnoreCase)).Any() ? result[permIdKey].ToString() : null;
+                entities.Add(new RosetteEntity(mention, normalized, entityID, type, count, confidence, dbpediaType, mentionOffsets, linkingConfidence, salience, permId));
             }
             this.Entities = entities;
         }

--- a/rosette_api/RosetteEntity.cs
+++ b/rosette_api/RosetteEntity.cs
@@ -123,6 +123,7 @@ namespace rosette_api
         /// <summary>
         /// Gets or sets the dbpediaType of the extracted entity
         /// </summary>
+        [Obsolete("Use dbPediaTypes instead.")]
         [JsonProperty("dbpediaType", NullValueHandling = NullValueHandling.Ignore)]
         public String DBpediaType { get; set; }
 

--- a/rosette_api/RosetteEntity.cs
+++ b/rosette_api/RosetteEntity.cs
@@ -198,7 +198,7 @@ namespace rosette_api
                 && MentionOffsets.SequenceEqual(other.MentionOffsets)
                 && LinkingConfidence.Equals(other.LinkingConfidence)
                 && Salience.Equals(other.Salience)
-                && PermID.Equals(other.PermID);
+                && string.Equals(PermID, other.PermID);
         }
 
         /// <summary>

--- a/rosette_api/RosetteEntity.cs
+++ b/rosette_api/RosetteEntity.cs
@@ -191,7 +191,7 @@ namespace rosette_api
         }
 
         /// <summary>
-        /// Compartor for Lists of Strings.  SequenceEqual throws an exception
+        /// Method to compare Lists of Strings.  SequenceEqual throws an exception
         /// if either argument is null.
         /// </summary>
         /// <param name="list1">List<String></param>

--- a/rosette_api/RosetteEntity.cs
+++ b/rosette_api/RosetteEntity.cs
@@ -145,6 +145,12 @@ namespace rosette_api
         public Nullable<double> Salience { get; set; }
 
         /// <summary>
+        /// Gets or sets the permId of the extracted entity
+        /// </summary>
+        [JsonProperty("permId", NullValueHandling = NullValueHandling.Ignore)]
+        public String PermID { get; set; }
+
+        /// <summary>
         /// Creates an entity
         /// </summary>
         /// <param name="mention">The mention of the entity</param>
@@ -157,9 +163,10 @@ namespace rosette_api
         /// <param name="mentionOffsets">The mention offsets of the entity</param>
         /// <param name="linkingConfidence">The linking confidence of the entity</param>
         /// <param name="salience">The salience of the entity</param>
+        /// <param name="permId">The Thomson Reuters Permanent Identifier of the entity</param>
         public RosetteEntity(string mention, string normalizedMention, EntityID id, string entityType, int? count,
             double? confidence, string dbpediaType, List<MentionOffset> mentionOffsets, double? linkingConfidence,
-            double? salience)
+            double? salience, string permId)
         {
             this.Mention = mention;
             this.NormalizedMention = normalizedMention;
@@ -171,6 +178,7 @@ namespace rosette_api
             this.MentionOffsets = mentionOffsets;
             this.LinkingConfidence = linkingConfidence;
             this.Salience = salience;
+            this.PermID = permId;
         }
 
         /// <summary>
@@ -189,7 +197,8 @@ namespace rosette_api
                 && string.Equals(DBpediaType, other.DBpediaType)
                 && MentionOffsets.SequenceEqual(other.MentionOffsets)
                 && LinkingConfidence.Equals(other.LinkingConfidence)
-                && Salience.Equals(other.Salience);
+                && Salience.Equals(other.Salience)
+                && PermID.Equals(other.PermID);
         }
 
         /// <summary>
@@ -223,6 +232,7 @@ namespace rosette_api
                 hashCode = (hashCode * 397) ^ (MentionOffsets != null ? MentionOffsets.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (LinkingConfidence != null ? LinkingConfidence.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Salience != null ? Salience.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (PermID != null ? PermID.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/rosette_api/RosetteEntity.cs
+++ b/rosette_api/RosetteEntity.cs
@@ -190,6 +190,20 @@ namespace rosette_api
         }
 
         /// <summary>
+        /// Compartor for Lists of Strings.  SequenceEqual throws an exception
+        /// if either argument is null.
+        /// </summary>
+        /// <param name="list1">List<String></param>
+        /// <param name="list2">List<String></param>
+        /// <returns>True if equal or both null</returns>
+        private bool StringListsAreEqual(List<String> list1, List<String> list2)
+        {
+            if(list1 == null && list2 == null) { return true; }
+            if(list1 == null || list2 == null) { return false; } // only one is null
+            return list1.SequenceEqual(list2);
+        }
+
+        /// <summary>
         /// Equals for RosetteEntity
         /// </summary>
         /// <param name="other">RosetteEntity</param>
@@ -203,7 +217,7 @@ namespace rosette_api
                 && Count == other.Count
                 && Confidence.Equals(other.Confidence)
                 && string.Equals(DBpediaType, other.DBpediaType)
-                && ((DBpediaTypes == null && other.DBpediaTypes == null) || DBpediaTypes.SequenceEqual(other.DBpediaTypes))
+                && StringListsAreEqual(DBpediaTypes, other.DBpediaTypes)
                 && MentionOffsets.SequenceEqual(other.MentionOffsets)
                 && LinkingConfidence.Equals(other.LinkingConfidence)
                 && Salience.Equals(other.Salience)

--- a/rosette_api/RosetteEntity.cs
+++ b/rosette_api/RosetteEntity.cs
@@ -127,6 +127,12 @@ namespace rosette_api
         public String DBpediaType { get; set; }
 
         /// <summary>
+        /// Gets or sets the dbpediaTypes of the extracted entity
+        /// </summary>
+        [JsonProperty("dbpediaTypes", NullValueHandling = NullValueHandling.Ignore)]
+        public List<String> DBpediaTypes { get; set; }
+
+        /// <summary>
         /// Gets or sets the offsets of the extracted entity
         /// </summary>
         [JsonProperty("mentionOffsets")]
@@ -160,13 +166,14 @@ namespace rosette_api
         /// <param name="count">The number of times this entity appeared in the input to the API</param>
         /// <param name="confidence">The confidence of this entity appeared in the input to the API</param>
         /// <param name="dbpediaType">The DBpedia type of the entity</param>
+        /// <param name="dbpediaTypes">A list of DBpedia types of the entitiy</param>
         /// <param name="mentionOffsets">The mention offsets of the entity</param>
         /// <param name="linkingConfidence">The linking confidence of the entity</param>
         /// <param name="salience">The salience of the entity</param>
         /// <param name="permId">The Thomson Reuters Permanent Identifier of the entity</param>
         public RosetteEntity(string mention, string normalizedMention, EntityID id, string entityType, int? count,
-            double? confidence, string dbpediaType, List<MentionOffset> mentionOffsets, double? linkingConfidence,
-            double? salience, string permId)
+            double? confidence, string dbpediaType, List<String> dbpediaTypes, List<MentionOffset> mentionOffsets,
+            double? linkingConfidence, double? salience, string permId)
         {
             this.Mention = mention;
             this.NormalizedMention = normalizedMention;
@@ -175,6 +182,7 @@ namespace rosette_api
             this.EntityType = entityType;
             this.Confidence = confidence;
             this.DBpediaType = dbpediaType;
+            this.DBpediaTypes = dbpediaTypes;
             this.MentionOffsets = mentionOffsets;
             this.LinkingConfidence = linkingConfidence;
             this.Salience = salience;
@@ -195,6 +203,7 @@ namespace rosette_api
                 && Count == other.Count
                 && Confidence.Equals(other.Confidence)
                 && string.Equals(DBpediaType, other.DBpediaType)
+                && ((DBpediaTypes == null && other.DBpediaTypes == null) || DBpediaTypes.SequenceEqual(other.DBpediaTypes))
                 && MentionOffsets.SequenceEqual(other.MentionOffsets)
                 && LinkingConfidence.Equals(other.LinkingConfidence)
                 && Salience.Equals(other.Salience)
@@ -229,6 +238,7 @@ namespace rosette_api
                 hashCode = (hashCode * 397) ^ Count.GetHashCode();
                 hashCode = (hashCode * 397) ^ Confidence.GetHashCode();
                 hashCode = (hashCode * 397) ^ (DBpediaType != null ? DBpediaType.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (DBpediaTypes != null ? DBpediaTypes.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (MentionOffsets != null ? MentionOffsets.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (LinkingConfidence != null ? LinkingConfidence.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Salience != null ? Salience.GetHashCode() : 0);

--- a/rosette_api/SentimentResponse.cs
+++ b/rosette_api/SentimentResponse.cs
@@ -31,6 +31,7 @@ namespace rosette_api
         internal const String mentionOffsetsKey = "mentionOffsets";
         internal const String linkingConfidenceKey = "linkingConfidence";
         internal const String salienceKey = "salience";
+        internal const String permIdKey = "permId";
 
         /// <summary>
         /// Gets or sets the document-level sentiment identified by the Rosette API
@@ -70,11 +71,12 @@ namespace rosette_api
                 List<MentionOffset> mentionOffsets = mentionOffsetsArr != null ? mentionOffsetsArr.ToObject<List<MentionOffset>>() : null;
                 Nullable<double> linkingConfidence = result.Properties().Where((p) => p.Name == linkingConfidenceKey).Any() ? result[linkingConfidenceKey].ToObject<double?>() : null;
                 Nullable<double> salience = result.Properties().Where((p) => p.Name == salienceKey).Any() ? result[salienceKey].ToObject<double?>() : null;
+                String permId = result.Properties().Where((p) => p.Name == permIdKey).Any() ? result[permIdKey].ToString() : null;
                 RosetteSentiment sentiment = null;
                 if (result.Properties().Where((p) => p.Name == sentimentKey).Any()) {
                     sentiment = result[sentimentKey].ToObject<RosetteSentiment>();
                 }
-                entitySentiments.Add(new RosetteSentimentEntity(mention, normalizedMention, entityID, type, count, sentiment, confidence, dbpediaType, mentionOffsets, linkingConfidence, salience));
+                entitySentiments.Add(new RosetteSentimentEntity(mention, normalizedMention, entityID, type, count, sentiment, confidence, dbpediaType, mentionOffsets, linkingConfidence, salience, permId));
             }
             this.EntitySentiments = entitySentiments;
         }
@@ -285,6 +287,7 @@ namespace rosette_api
         /// <param name="mentionOffsets">The mention offsets of the entity</param>
         /// <param name="linkingConfidence">The linking confidence of the entity</param>
         /// <param name="salience">The salience of the entity</param>
+        /// <param name="permId">The Thomson Reuters Permanent Identifier of the entity</param>
         public RosetteSentimentEntity(string mention,
                                       string normalizedMention,
                                       EntityID id,
@@ -295,7 +298,8 @@ namespace rosette_api
                                       string dbpediaType,
                                       List<MentionOffset> mentionOffsets,
                                       double? linkingConfidence,
-                                      double? salience
+                                      double? salience,
+                                      String permId
                                      ) : base(mention,
                                               normalizedMention,
                                               id,
@@ -305,7 +309,8 @@ namespace rosette_api
                                               dbpediaType,
                                               mentionOffsets,
                                               linkingConfidence,
-                                              salience
+                                              salience,
+                                              permId
                                              )
         {
             this.Sentiment = new SentimentResponse.RosetteSentiment(sentiment.Label, sentiment.Confidence);

--- a/rosette_api/SentimentResponse.cs
+++ b/rosette_api/SentimentResponse.cs
@@ -24,6 +24,7 @@ namespace rosette_api
         internal const string mentionKey = "mention";
         internal const string normalizedMentionKey = "normalized";
         internal const string dbpediaTypeKey = "dbpediaType";
+        internal const string dbpediaTypesKey = "dbpediaTypes";
         internal const string countKey = "count";
         internal const string typeKey = "type";
         internal const string entityIDKey = "entityId";
@@ -65,6 +66,7 @@ namespace rosette_api
                 string entityIDStr = result.Properties().Where((p) => p.Name == entityIDKey).Any() ? result[entityIDKey].ToString() : null;
                 EntityID entityID = entityIDStr != null ? new EntityID(entityIDStr) : null;
                 string dbpediaType = result.Properties().Where((p) => p.Name == dbpediaTypeKey).Any() ? result[dbpediaTypeKey].ToString() : null;
+                List<String> dbpediaTypes = result.Properties().Where((permIdKey) => permIdKey.Name == dbpediaTypesKey).Any() ? result[dbpediaTypesKey].ToObject<List<String>>() : null;
                 Nullable<int> count = result.Properties().Where((p) => p.Name == countKey).Any() ? result[countKey].ToObject<int?>() : null;
                 Nullable<double> confidence = result.Properties().Where((p) => String.Equals(p.Name, confidenceKey)).Any() ? result[confidenceKey].ToObject<double?>() : null;
                 JArray mentionOffsetsArr = result.Properties().Where((p) => p.Name == mentionOffsetsKey).Any() ? result[mentionOffsetsKey] as JArray : null;
@@ -76,7 +78,7 @@ namespace rosette_api
                 if (result.Properties().Where((p) => p.Name == sentimentKey).Any()) {
                     sentiment = result[sentimentKey].ToObject<RosetteSentiment>();
                 }
-                entitySentiments.Add(new RosetteSentimentEntity(mention, normalizedMention, entityID, type, count, sentiment, confidence, dbpediaType, mentionOffsets, linkingConfidence, salience, permId));
+                entitySentiments.Add(new RosetteSentimentEntity(mention, normalizedMention, entityID, type, count, sentiment, confidence, dbpediaType, dbpediaTypes, mentionOffsets, linkingConfidence, salience, permId));
             }
             this.EntitySentiments = entitySentiments;
         }
@@ -284,6 +286,7 @@ namespace rosette_api
         /// <param name="sentiment">The contextual sentiment of the entity</param>
         /// <param name="confidence">The confidence that the sentiment was correctly identified</param>
         /// <param name="dbpediaType">The DBpedia type of the entity</param>
+        /// <param name="dbpediaTypes">A list of DBpedia types of the entitiy</param>
         /// <param name="mentionOffsets">The mention offsets of the entity</param>
         /// <param name="linkingConfidence">The linking confidence of the entity</param>
         /// <param name="salience">The salience of the entity</param>
@@ -296,6 +299,7 @@ namespace rosette_api
                                       SentimentResponse.RosetteSentiment sentiment,
                                       double? confidence,
                                       string dbpediaType,
+                                      List<String> dbpediaTypes,
                                       List<MentionOffset> mentionOffsets,
                                       double? linkingConfidence,
                                       double? salience,
@@ -307,6 +311,7 @@ namespace rosette_api
                                               count,
                                               confidence,
                                               dbpediaType,
+                                              dbpediaTypes,
                                               mentionOffsets,
                                               linkingConfidence,
                                               salience,

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -473,7 +473,6 @@ namespace rosette_apiUnitTests {
             string buildNumber = null;
             string buildTime = null;
             string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
-
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "name", name },
                 { "version", version },

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -667,11 +667,12 @@ namespace rosette_apiUnitTests {
         }
 
         [Test]
-        public void EntityTestExtendedProperties()
-        {
+        public void EntityTestExtendedProperties() {
+            // Entities response, based on Cloud defaults, with linkEntities,
+            // includeDBpediaType, includeDBpediaTypes and includePermID set to true.
+
             Init();
-            // Entities response, based on a Cloud call,
-            // with linkEntities, includeDBpediaType, includeDBpediaTypes and includePermID set to true.
+
             String e_type = "ORGANIZATION";
             String e_mention = "Toyota";
             String e_normalized = "Toyota";
@@ -685,20 +686,24 @@ namespace rosette_apiUnitTests {
             List<String> e_dbpediaTypes = new List<String>() {"Agent/Organisation"};
             String e_permId = "4295876746";
 
-            RosetteEntity e = new RosetteEntity(e_mention, e_normalized, e_entityID, e_type, e_count, e_confidence, e_dbpediaType, e_dbpediaTypes, e_mentionOffsets, e_linkingConfidence, e_salience, e_permId);
-
+            RosetteEntity e = new RosetteEntity(e_mention, e_normalized, e_entityID, e_type, e_count, e_confidence,
+                e_dbpediaType, e_dbpediaTypes, e_mentionOffsets, e_linkingConfidence, e_salience, e_permId);
             List<RosetteEntity> entities = new List<RosetteEntity>() { e };
+            Dictionary<string, object> content = new Dictionary<string, object> { { "entities", entities } };
+
             string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
-            Dictionary<string, object> content = new Dictionary<string, object> {
-                { "entities", entities }
-            };
+
             EntitiesResponse expected = new EntitiesResponse(entities, responseHeaders, content, null);
             String mockedContent = expected.ContentToString();
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
             _mockHttp.When(_testUrl + "entities").Respond(req => mockedMessage);
             EntitiesResponse response = _rosetteApi.Entity("Toyota");
+
             Assert.AreEqual(expected, response);
+            Assert.AreEqual(expected.Entities[0].PermID, response.Entities[0].PermID);
+            Assert.AreEqual(expected.Entities[0].DBpediaType, response.Entities[0].DBpediaType);
+            Assert.AreEqual(expected.Entities[0].DBpediaTypes, response.Entities[0].DBpediaTypes);
         }
 
         [Test]

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -472,7 +472,8 @@ namespace rosette_apiUnitTests {
             string version = "1.2.3";
             string buildNumber = null;
             string buildTime = null;
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": 72, \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
+
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "name", name },
                 { "version", version },
@@ -525,7 +526,7 @@ namespace rosette_apiUnitTests {
             Init();
             string message = "Rosette API at your service.";
             long time = 1470930452887;
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "message", message },
                 { "time", time }
@@ -607,7 +608,7 @@ namespace rosette_apiUnitTests {
             List<RosetteCategory> categories = new List<RosetteCategory>();
             RosetteCategory cat0 = new RosetteCategory("ARTS_AND_ENTERTAINMENT", (decimal)0.23572849069656435, (decimal)0.12312312312312312);
             categories.Add(cat0);
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "categories", categories }
             };
@@ -649,11 +650,11 @@ namespace rosette_apiUnitTests {
         public void EntityTestFull()
         {
             Init();
-            RosetteEntity e0 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20,32) }, .99, 1);
-            RosetteEntity e1 = new RosetteEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, null, "X1", new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null);
-            RosetteEntity e2 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 0.0);
+            RosetteEntity e0 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20,32) }, .99, 1, null);
+            RosetteEntity e1 = new RosetteEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, null, "X1", new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null, null);
+            RosetteEntity e2 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 0.0, null);
             List<RosetteEntity> entities = new List<RosetteEntity>() { e0, e1, e2 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "entities", entities }
@@ -663,6 +664,57 @@ namespace rosette_apiUnitTests {
             HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
             _mockHttp.When(_testUrl + "entities").Respond(req => mockedMessage);
             EntitiesResponse response = _rosetteApi.Entity("Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t be more pleased with the new all-female Ghostbusters cast, telling The Hollywood Reporter, “The Aykroyd family is delighted by this inheritance of the Ghostbusters torch by these most magnificent women in comedy.”");
+            Assert.AreEqual(expected, response);
+        }
+
+        [Test]
+        public void EntityTestExtendedProperties()
+        {
+            //String type;
+            //String mention;
+            //String entityIDStr;
+            //EntityID entityID;
+            //String normalized;
+            //Nullable<int> count;
+            //Nullable<double> confidence;
+            //String dbpediaType;
+            //List<String> dbpediaTypes;
+            //String permID;
+            //List<MentionOffset> mentionOffsets;
+            //Nullable<double> linkingConfidence;
+            //Nullable<double> salience;
+
+            Init();
+            // Entities response, based on a Cloud call, with linkEntities, includeDBpediaType and includePermID set to true.
+            String e_type = "ORGANIZATION";
+            String e_mention = "Toyota";
+            String e_normalized = "Toyota";
+            Nullable<int> e_count = 1;
+            Nullable<double> e_confidence = null;
+            List<MentionOffset> e_mentionOffsets = new List<MentionOffset>() { new MentionOffset(0, 6) };
+            EntityID e_entityID = new EntityID("Q53268");
+            Nullable<double> e_linkingConfidence = 0.14286868;
+            Nullable<double> e_salience = null;
+            String e_dbpediaType = "Agent/Organisation/Company";
+            String e_permId = "4295876746";
+
+            // RosetteEntity(string mention, string normalizedMention, EntityID id, string entityType, int? count,
+            //double? confidence, string dbpediaType, List<MentionOffset> mentionOffsets, double? linkingConfidence,
+            //double? salience)
+            RosetteEntity e = new RosetteEntity(e_mention, e_normalized, e_entityID, e_type, e_count, e_confidence, e_dbpediaType, e_mentionOffsets, e_linkingConfidence, e_salience, e_permId);
+            //RosetteEntity e = new RosetteEntity("Toyota", "Toyota", new EntityID("Q53268"), "ORGANIZATION", 1, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20,32) }, .99, 1);
+
+            List<RosetteEntity> entities = new List<RosetteEntity>() { e };
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
+            Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "entities", entities }
+            };
+            EntitiesResponse expected = new EntitiesResponse(entities, responseHeaders, content, null);
+            String mockedContent = expected.ContentToString();
+            HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
+            _mockHttp.When(_testUrl + "entities").Respond(req => mockedMessage);
+            EntitiesResponse response = _rosetteApi.Entity("Toyota");
             Assert.AreEqual(expected, response);
         }
 
@@ -740,7 +792,7 @@ namespace rosette_apiUnitTests {
             LanguageDetection lang7 = new LanguageDetection("fin", (decimal)0.23572849069656435);
             LanguageDetection lang8 = new LanguageDetection("fra", (decimal)0.023298946617300347);
             List<LanguageDetection> languageDetections = new List<LanguageDetection>() { lang0, lang1, lang2, lang3, lang4, lang5, lang6, lang7, lang8 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "languageDetections", languageDetections }
@@ -799,7 +851,7 @@ namespace rosette_apiUnitTests {
             MorphologyItem m4 = new MorphologyItem("jumped", "VERB", "jump", new List<string>(), new List<string>());
             MorphologyItem m5 = new MorphologyItem(".", "PUNCT", ".", new List<string>(), new List<string>());
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1, m2, m3, m4, m5 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) },
@@ -827,7 +879,7 @@ namespace rosette_apiUnitTests {
             MorphologyItem m4 = new MorphologyItem("jumped", null, "jump", null, null);
             MorphologyItem m5 = new MorphologyItem(".", null, ".", null, null);
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1, m2, m3, m4, m5 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) }
@@ -850,7 +902,7 @@ namespace rosette_apiUnitTests {
             List<string> compoundComponents = new List<string>() { "Rechts", "Schutz", "Versicherungs", "Gesellschaft" };
             MorphologyItem m1 = new MorphologyItem("Rechtsschutzversicherungsgesellschaft", null, null, compoundComponents, null);
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) }
@@ -876,7 +928,7 @@ namespace rosette_apiUnitTests {
             MorphologyItem m1 = new MorphologyItem("生物系", null, null, null, h1);
             MorphologyItem m2 = new MorphologyItem("主任", null, null, null, h2);
             List<MorphologyItem> morphology = new List<MorphologyItem>() { m0, m1, m2 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "tokens", new List<string>(morphology.Select<MorphologyItem, string>((item) => item.Token)) }
@@ -931,7 +983,7 @@ namespace rosette_apiUnitTests {
         {
             Init();
             double score = (double)0.9486632809417912;
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "score", score }
@@ -1051,7 +1103,7 @@ namespace rosette_apiUnitTests {
             string loc1 = "in Boston";
             List<string> locatives = new List<string>() {loc1};
             HashSet<string> modalities = new HashSet<string>() {"assertion", "someOtherModality"};
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             List<RosetteRelationship> relationships = new List<RosetteRelationship>() {
                 new RosetteRelationship(predicate, new Dictionary<int, string>() {{1, arg1}}, new Dictionary<int, string>() {{1, arg1ID}}, null, locatives, null, confidence, modalities)
@@ -1077,7 +1129,7 @@ namespace rosette_apiUnitTests {
             string loc1 = "in Boston";
             List<string> locatives = new List<string>() { loc1 };
             HashSet<string> modalities = new HashSet<string>() { "assertion", "someOtherModality" };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             List<RosetteRelationship> relationships = new List<RosetteRelationship>() {
                 new RosetteRelationship(predicate, new Dictionary<int, string>() {{1, arg1}}, new Dictionary<int, string>(), null, locatives, null, confidence, modalities)
@@ -1149,7 +1201,7 @@ namespace rosette_apiUnitTests {
         {
             Init();
             List<double> vector = new List<double>() {0.02164695, 0.0032850206, 0.0038508752, -0.009704393, -0.0016203842};
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "documentEmbedding", vector },
@@ -1209,7 +1261,7 @@ namespace rosette_apiUnitTests {
             IDictionary<string, List<SimilarTerm>> terms = new Dictionary<string, List<SimilarTerm>>() {
                 {"eng", new List<SimilarTerm>() {new SimilarTerm("spy", 1.0m)}}
             };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object>() {
                 {"similarTerms", terms}
@@ -1269,7 +1321,7 @@ namespace rosette_apiUnitTests {
             string s1 = "This land is my land\nFrom California to the New York island;\nFrom the red wood forest to the Gulf Stream waters\n\nThis land was made for you and Me.\n\n";
             string s2 = "As I was walking that ribbon of highway,\nI saw above me that endless skyway:\nI saw below me that golden valley:\nThis land was made for you and me.";
             List<string> sentences = new List<string>() { s0, s1, s2 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "sentences", sentences }
@@ -1322,10 +1374,10 @@ namespace rosette_apiUnitTests {
         {
             Init();
             SentimentResponse.RosetteSentiment docSentiment = new SentimentResponse.RosetteSentiment("pos", (double)0.7962072011038756);
-            RosetteSentimentEntity e0 = new RosetteSentimentEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, docSentiment, (double)0.5005508052749595, null, new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 1);
-            RosetteSentimentEntity e1 = new RosetteSentimentEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, docSentiment, (double)0.5338094035254866, null, new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null);
+            RosetteSentimentEntity e0 = new RosetteSentimentEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, docSentiment, (double)0.5005508052749595, null, new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 1, null);
+            RosetteSentimentEntity e1 = new RosetteSentimentEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, docSentiment, (double)0.5338094035254866, null, new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null, null);
             List<RosetteSentimentEntity> entities = new List<RosetteSentimentEntity>() { e0, e1 };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "document", docSentiment },
@@ -1386,7 +1438,7 @@ namespace rosette_apiUnitTests {
             SyntaxDependenciesResponse.SentenceWithDependencies sentence = new SyntaxDependenciesResponse.SentenceWithDependencies(0, 4, dependencies);
             List<SyntaxDependenciesResponse.SentenceWithDependencies> sentences = new List<SyntaxDependenciesResponse.SentenceWithDependencies>() { sentence };
             List<string> tokens = new List<string>() { "Sony", "Pictures", "is", "planning", "."};
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "sentences", sentences },
@@ -1450,7 +1502,7 @@ namespace rosette_apiUnitTests {
                 "内部",
                 "会议"
             };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "tokens", tokens }
@@ -1507,7 +1559,7 @@ namespace rosette_apiUnitTests {
             string targetScript = "Latn";
             string targetScheme = "IC";
             double confidence = (double)0.06856099342585828;
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "translation", translation },
@@ -1573,7 +1625,7 @@ namespace rosette_apiUnitTests {
                 new KeyPhrase("Scorpius Malfoy", null),
                 new KeyPhrase("Nicholas Hoult", null)
             };
-            string headersAsString = " { \"Content-Type\": \"application/json\", \"date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"server\": \"openresty\", \"strict-transport-security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"content-length\": \"72\", \"connection\": \"Close\" }";
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
             Dictionary<string, object> content = new Dictionary<string, object> {
                 { "concepts", concepts },

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -649,9 +649,9 @@ namespace rosette_apiUnitTests {
         public void EntityTestFull()
         {
             Init();
-            RosetteEntity e0 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20,32) }, .99, 1, null);
-            RosetteEntity e1 = new RosetteEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, null, "X1", new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null, null);
-            RosetteEntity e2 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 0.0, null);
+            RosetteEntity e0 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", null, new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20,32) }, .99, 1, null);
+            RosetteEntity e1 = new RosetteEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, null, "X1", null, new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null, null);
+            RosetteEntity e2 = new RosetteEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, 0.99, "X1", null, new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 0.0, null);
             List<RosetteEntity> entities = new List<RosetteEntity>() { e0, e1, e2 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
@@ -669,22 +669,9 @@ namespace rosette_apiUnitTests {
         [Test]
         public void EntityTestExtendedProperties()
         {
-            //String type;
-            //String mention;
-            //String entityIDStr;
-            //EntityID entityID;
-            //String normalized;
-            //Nullable<int> count;
-            //Nullable<double> confidence;
-            //String dbpediaType;
-            //List<String> dbpediaTypes;
-            //String permID;
-            //List<MentionOffset> mentionOffsets;
-            //Nullable<double> linkingConfidence;
-            //Nullable<double> salience;
-
             Init();
-            // Entities response, based on a Cloud call, with linkEntities, includeDBpediaType and includePermID set to true.
+            // Entities response, based on a Cloud call,
+            // with linkEntities, includeDBpediaType, includeDBpediaTypes and includePermID set to true.
             String e_type = "ORGANIZATION";
             String e_mention = "Toyota";
             String e_normalized = "Toyota";
@@ -694,14 +681,11 @@ namespace rosette_apiUnitTests {
             EntityID e_entityID = new EntityID("Q53268");
             Nullable<double> e_linkingConfidence = 0.14286868;
             Nullable<double> e_salience = null;
-            String e_dbpediaType = "Agent/Organisation/Company";
+            String e_dbpediaType = "Agent/Organisation";
+            List<String> e_dbpediaTypes = new List<String>() {"Agent/Organisation"};
             String e_permId = "4295876746";
 
-            // RosetteEntity(string mention, string normalizedMention, EntityID id, string entityType, int? count,
-            //double? confidence, string dbpediaType, List<MentionOffset> mentionOffsets, double? linkingConfidence,
-            //double? salience)
-            RosetteEntity e = new RosetteEntity(e_mention, e_normalized, e_entityID, e_type, e_count, e_confidence, e_dbpediaType, e_mentionOffsets, e_linkingConfidence, e_salience, e_permId);
-            //RosetteEntity e = new RosetteEntity("Toyota", "Toyota", new EntityID("Q53268"), "ORGANIZATION", 1, "X1", new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20,32) }, .99, 1);
+            RosetteEntity e = new RosetteEntity(e_mention, e_normalized, e_entityID, e_type, e_count, e_confidence, e_dbpediaType, e_dbpediaTypes, e_mentionOffsets, e_linkingConfidence, e_salience, e_permId);
 
             List<RosetteEntity> entities = new List<RosetteEntity>() { e };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
@@ -1373,8 +1357,8 @@ namespace rosette_apiUnitTests {
         {
             Init();
             SentimentResponse.RosetteSentiment docSentiment = new SentimentResponse.RosetteSentiment("pos", (double)0.7962072011038756);
-            RosetteSentimentEntity e0 = new RosetteSentimentEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, docSentiment, (double)0.5005508052749595, null, new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 1, null);
-            RosetteSentimentEntity e1 = new RosetteSentimentEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, docSentiment, (double)0.5338094035254866, null, new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null, null);
+            RosetteSentimentEntity e0 = new RosetteSentimentEntity("Dan Akroyd", "Dan Akroyd", new EntityID("Q105221"), "PERSON", 2, docSentiment, (double)0.5005508052749595, null, null, new List<MentionOffset>() { new MentionOffset(0, 10), new MentionOffset(20, 32) }, .99, 1, null);
+            RosetteSentimentEntity e1 = new RosetteSentimentEntity("The Hollywood Reporter", "The Hollywood Reporter", new EntityID("Q61503"), "ORGANIZATION", 1, docSentiment, (double)0.5338094035254866, null, null, new List<MentionOffset>() { new MentionOffset(15, 18) }, null, null, null);
             List<RosetteSentimentEntity> entities = new List<RosetteSentimentEntity>() { e0, e1 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
             Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);


### PR DESCRIPTION
* Fixed unit test failures caused by header capitalization differences.
* New entity response field, `permId`, added.
* New entity response field, `dbpediaTypes`, added.
* Unit test specifically for entity extended properties.
* `mentionOffsetsArr` in `EntitiesResponse` was referencing `dbpediaTypeKey`.
* Marked `dbpediaType` as obsolete.
