### PR TITLE
WS-2589: Remove genre option from entities example

### DIFF
--- a/rosette_api/CAPI.cs
+++ b/rosette_api/CAPI.cs
@@ -1379,6 +1379,10 @@ namespace rosette_api {
                 }
             }
 
+            if (genre == null) {
+                Console.WriteLine("warn: The genre parameter is deprecated and will be removed in a future release.");
+            }
+
             Dictionary<object, object> dict = new Dictionary<object, object>(){
                 { "language", language},
                 { "content", content},

--- a/rosette_api/CAPI.cs
+++ b/rosette_api/CAPI.cs
@@ -1379,7 +1379,7 @@ namespace rosette_api {
                 }
             }
 
-            if (genre == null) {
+            if (genre != null) {
                 Console.WriteLine("warn: The genre parameter is deprecated and will be removed in a future release.");
             }
 


### PR DESCRIPTION
This PR is needed to add a warning in case the `genre` field is not null. The good news is that the `genre` field is not being used in the examples.