### PR TITLE
WS-2785: added tests for events and event negation

### DIFF
--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -805,6 +805,67 @@ namespace rosette_apiUnitTests {
             Assert.AreEqual(null, eid.GetWikipedaURL());
         }
 
+        //------------------------- Event ----------------------------------------
+        [Test]
+        public void EventTestFull()
+        {
+            Init();
+            RosetteEvent e0 = new RosetteEvent("DATA-1275-Meet-Travel.TRAVEL", new List<EventMention>() {
+            new EventMention(new List<EventRole> { new EventRole("key", "E1", "travel", null, null, null, 15, 21) },
+            "Negative", null, new List<NegationCue> { new NegationCue("not", 11, 14) }, 15, 21) }, 0.3333333333333333, "test");
+
+            List<RosetteEvent> events = new List<RosetteEvent>() { e0 };
+            string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";
+            Dictionary<string, string> responseHeaders = new JavaScriptSerializer().Deserialize<Dictionary<string, string>>(headersAsString);
+            Dictionary<string, object> content = new Dictionary<string, object> {
+                { "events", events }
+            };
+            EventsResponse expected = new EventsResponse(events, responseHeaders, content, null);
+            String mockedContent = expected.ContentToString();
+            HttpResponseMessage mockedMessage = MakeMockedMessage(responseHeaders, HttpStatusCode.OK, mockedContent);
+            _mockHttp.When(_testUrl + "events").Respond(req => mockedMessage);
+            _rosetteApi.SetOption("negation", "BOTH");
+            EventsResponse response = _rosetteApi.Event("Vivian went to Moscow.");
+            Assert.AreEqual(expected, response);
+        }
+
+        [Test]
+        public void Event_Content_Test()
+        {
+            _mockHttp.When(_testUrl + "events")
+                .Respond(HttpStatusCode.OK, "application/json", "{'response': 'OK'}");
+
+            var response = _rosetteApi.Event("content");
+# pragma warning disable 618
+            Assert.AreEqual(response.Content["response"], "OK");
+# pragma warning restore 618
+        }
+
+        [Test]
+        public void Event_Dict_Test()
+        {
+            _mockHttp.When(_testUrl + "events")
+                .Respond(HttpStatusCode.OK, "application/json", "{'response': 'OK'}");
+
+            var response = _rosetteApi.Event(new Dictionary<object, object>() { { "contentUri", "contentUrl" } });
+# pragma warning disable 618
+            Assert.AreEqual(response.Content["response"], "OK");
+# pragma warning restore 618
+        }
+
+        [Test]
+        public void Event_File_Test()
+        {
+            _mockHttp.When(_testUrl + "events")
+                .Respond("application/json", "{'response': 'OK'}");
+
+            RosetteFile f = new RosetteFile(_tmpFile);
+            var response = _rosetteApi.Event(f);
+# pragma warning disable 618
+            Assert.AreEqual(response.Content["response"], "OK");
+# pragma warning restore 618
+        }
+
         //------------------------- Language ----------------------------------------
 
         [Test]

--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -811,8 +811,8 @@ namespace rosette_apiUnitTests {
         {
             Init();
             RosetteEvent e0 = new RosetteEvent("DATA-1275-Meet-Travel.TRAVEL", new List<EventMention>() {
-            new EventMention(new List<EventRole> { new EventRole("key", "E1", "travel", null, null, null, 15, 21) },
-            "Negative", null, new List<NegationCue> { new NegationCue("not", 11, 14) }, 15, 21) }, 0.3333333333333333, "test");
+                new EventMention(new List<EventRole> { new EventRole("key", "E1", "travel", null, null, null, 15, 21) },
+                "Negative", null, new List<NegationCue> { new NegationCue("not", 11, 14) }, 15, 21) }, 0.3333333333333333, "test");
 
             List<RosetteEvent> events = new List<RosetteEvent>() { e0 };
             string headersAsString = " { \"Content-Type\": \"application/json\", \"Date\": \"Thu, 11 Aug 2016 15:47:32 GMT\", \"Server\": \"openresty\", \"Strict-Transport-Security\": \"max-age=63072000; includeSubdomains; preload\", \"x-rosetteapi-app-id\": \"1409611723442\", \"x-rosetteapi-concurrency\": \"50\", \"x-rosetteapi-request-id\": \"d4176692-4f14-42d7-8c26-4b2d8f7ff049\", \"Content-Length\": \"72\", \"Connection\": \"Close\" }";


### PR DESCRIPTION
Added tests follow the same format as other unit tests in checking if the correct response object is returned when the mock events endpoint is called.

Verification Steps:

- Check if newly added unit tests for events are correct and pass