### PR TITLE
TEJ-2091: Fix GetWikipediaURL function in C# binding

### DIFF
--- a/rosette_api/EntityID.cs
+++ b/rosette_api/EntityID.cs
@@ -40,7 +40,6 @@ namespace rosette_api
             string siteLink = ("https://www.wikidata.org/w/api.php?action=wbgetentities&ids=" + ID + "&sitefilter=enwiki&props=sitelinks&format=json");
             try
             {
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                 string jsonStr =  MakeRequest(siteLink).Result;
                 int lengthOfTitle = jsonStr.IndexOf("\"badges\":") - jsonStr.IndexOf("\"title\":") - 11;
                 string title = jsonStr.Substring(jsonStr.IndexOf("\"title\":") + 9, lengthOfTitle);
@@ -59,6 +58,7 @@ namespace rosette_api
         {
             try
             {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                 using (HttpClient client = new HttpClient())
                 using (HttpResponseMessage response = await client.GetAsync(requestUrl))
                 using (HttpContent content = response.Content) {

--- a/rosette_api/EntityID.cs
+++ b/rosette_api/EntityID.cs
@@ -58,11 +58,7 @@ namespace rosette_api
         {
             try
             {
-                ServicePointManager.Expect100Continue = true;
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
-                       | SecurityProtocolType.Tls11
-                       | SecurityProtocolType.Tls12
-                       | SecurityProtocolType.Ssl3;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                 using (HttpClient client = new HttpClient())
                 using (HttpResponseMessage response = await client.GetAsync(requestUrl))
                 using (HttpContent content = response.Content) {

--- a/rosette_api/EntityID.cs
+++ b/rosette_api/EntityID.cs
@@ -58,7 +58,11 @@ namespace rosette_api
         {
             try
             {
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                ServicePointManager.Expect100Continue = true;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
+                       | SecurityProtocolType.Tls11
+                       | SecurityProtocolType.Tls12
+                       | SecurityProtocolType.Ssl3;
                 using (HttpClient client = new HttpClient())
                 using (HttpResponseMessage response = await client.GetAsync(requestUrl))
                 using (HttpContent content = response.Content) {

--- a/rosette_api/EntityID.cs
+++ b/rosette_api/EntityID.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Net.Http;
 using System.IO;
 using Newtonsoft.Json;
+using System.Net;
 
 namespace rosette_api
 {
@@ -39,6 +40,7 @@ namespace rosette_api
             string siteLink = ("https://www.wikidata.org/w/api.php?action=wbgetentities&ids=" + ID + "&sitefilter=enwiki&props=sitelinks&format=json");
             try
             {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                 string jsonStr =  MakeRequest(siteLink).Result;
                 int lengthOfTitle = jsonStr.IndexOf("\"badges\":") - jsonStr.IndexOf("\"title\":") - 11;
                 string title = jsonStr.Substring(jsonStr.IndexOf("\"title\":") + 9, lengthOfTitle);

--- a/rosette_api/rosette_api.csproj
+++ b/rosette_api/rosette_api.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>rosette_api</RootNamespace>
     <AssemblyName>rosette_api</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>


### PR DESCRIPTION
Issue was that when GetWikipediaUrl() called MakeRequest(): client.getAsync was unable to create a secure SSL/TLS channel.