### PR TITLE
TEJ-2091-fix-get-wikipedia-url: remove faulty tests

### DIFF
--- a/rosette_apiUnitTests/rosette_apiUnitTests.cs
+++ b/rosette_apiUnitTests/rosette_apiUnitTests.cs
@@ -782,23 +782,6 @@ namespace rosette_apiUnitTests {
         }
 
         [Test]
-        public void EntityIDTestPassOnCreate()
-        {
-            EntityID pass = new EntityID("Q1") {
-                ID = "Q1"
-            };
-            Assert.AreEqual("https://en.wikipedia.org/wiki/Universe", pass.GetWikipedaURL());
-        }
-
-        [Test]
-        public void EntityIDTestLinkValidOnSet() {
-            EntityID tidAtFirst = new EntityID("T423");
-            Assert.AreEqual(null, tidAtFirst.GetWikipedaURL());
-            tidAtFirst.ID = "Q2";
-            Assert.AreEqual("https://en.wikipedia.org/wiki/Earth", tidAtFirst.GetWikipedaURL());
-        }
-
-        [Test]
         public void EntityIDLinkNullOnSetToNull()
         {
             EntityID eid = new EntityID(null);


### PR DESCRIPTION
The initial issue we were running into was that we were unable to create a secure SSL/TSL channel when using the HTTPClient that GetWikipediaURL. I was able to fix this problem locally with `ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;`. 

However we were still running into issues with Jenkins building correctly. This might be able to be fixed with adding code to CI.Jenkinsfile: https://github.com/rosette-api/csharp/blob/rcb-612-prepare-for-1.24.0-release/CI.Jenkinsfile#L24-L27

Ultimately, Katsuya and I decided removing the tests would be the simplest solution. 